### PR TITLE
chore: sync codex-stack fleet rollout

### DIFF
--- a/.codex-stack/fleet-member.json
+++ b/.codex-stack/fleet-member.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": 1,
-  "generatedAt": "2026-03-15T14:36:33.790Z",
+  "generatedAt": "2026-03-16T10:46:29.291Z",
   "controlRepo": "anup4khandelwal/codex-stack",
-  "controlRef": "796972bd9da6645172dc579a1cafad4004c90038",
+  "controlRef": "1173ea519374856abf675c7265992ce8412a0203",
   "sourceManifest": ".codex-stack/fleet.anup4khandelwal.json",
   "repo": "anup4khandelwal/autopilot-multi-agent-loop",
   "branch": "main",
@@ -37,6 +37,12 @@
   "decisions": {
     "staleAfterDays": 30,
     "expiringSoonDays": 7
+  },
+  "remediation": {
+    "autoOpenPrs": true,
+    "issueOnWarning": true,
+    "issueOnCritical": true,
+    "closeIssueWhenHealthy": true
   },
   "status": {
     "requiresLatestReport": false


### PR DESCRIPTION
Sync codex-stack fleet rollout files.

- refresh `.codex-stack/fleet-member.json`
- refresh `.github/codex-stack/fleet-status.js`
- refresh `.github/workflows/codex-stack-fleet-status.yml`